### PR TITLE
Open links in new tab by default

### DIFF
--- a/source/_templates/post.html
+++ b/source/_templates/post.html
@@ -43,12 +43,13 @@ limitations under the License.
   ${d.shareimg ? `<meta property="og:image" content="${d.shareimg}">`  : ''}
   ${d.shareimg ? `<meta name="twitter:card" content="summary_large_image">` : ''}
   
-	<link rel="stylesheet" type="text/css" href="../style.css">
+  <link rel="stylesheet" type="text/css" href="../style.css">
 
   <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,500,700|Roboto:700,500,300' rel='stylesheet' type='text/css'>  
   <link href="https://fonts.googleapis.com/css?family=Google+Sans:400,500,700" rel="stylesheet">
 
-	<meta name="viewport" content="width=device-width">
+  <meta name="viewport" content="width=device-width">
+  <base target="_blank">
 </head>
 <body>
   <div class='header'>


### PR DESCRIPTION
While playing with explorables on the Hub, we noticed that links are opened by default in the same tab. By adding `<base target="_blank">` in the head, all links will open in a new tab by default. This works as long as `<a>` does not have a target attribute already. Is this a change you would be ok with?